### PR TITLE
remove conda env

### DIFF
--- a/pipelines/combine-zarr-sample-genotypes/Snakefile
+++ b/pipelines/combine-zarr-sample-genotypes/Snakefile
@@ -52,8 +52,6 @@ rule merge_zarr:
     num_workers=4,
     req="h_vmem=6G",
     pe="-pe simple_pe 4"
-  conda:
-    "env.yml"
   script:
     "../../scripts/combine_zarr.py"
 

--- a/pipelines/combine-zarr-sample-genotypes/sge-submit.sh
+++ b/pipelines/combine-zarr-sample-genotypes/sge-submit.sh
@@ -2,10 +2,7 @@
 snakemake --snakefile `dirname $0`/Snakefile $@ \
     --cluster 'qsub -v PATH="binder/deps/conda/bin::$PATH" -j y -b n -l {params.req},h=!foxtrot.well.ox.ac.uk -S /bin/bash' \
     --jobs 50 \
-    --ri \
     --latency-wait 300 \
-    --max-jobs-per-second 0.1 \
-    --max-status-checks-per-second 0.1 \
-    --restart-times 1 \
+    --restart-times 0 \
     --jn "{rulename}.{jobid}.sh" \
     --use-conda


### PR DESCRIPTION
no use for conda env when using binder